### PR TITLE
Add RAG integration and improved sentiment model

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,26 +1,40 @@
-# Importing essential libraries
 from flask import Flask, render_template, request
-import pickle
 
-# Load the Multinomial Naive Bayes model and CountVectorizer object from disk
-filename = 'restaurant-sentiment-mnb-model.pkl'
-classifier = pickle.load(open(filename, 'rb'))
-cv = pickle.load(open('cv-transform.pkl','rb'))
+# Local modules for sentiment and RAG
+from rag_helper import init_rag, retrieve_context
+from sentiment_model import SentimentModel, classify_label
 
 app = Flask(__name__)
 
+# initialize RAG components and the sentiment model
+init_rag()
+sentiment_model = SentimentModel()
+
+
 @app.route('/')
 def home():
-	return render_template('index.html')
+    return render_template('index.html')
+
 
 @app.route('/predict', methods=['POST'])
 def predict():
     if request.method == 'POST':
-    	message = request.form['message']
-    	data = [message]
-    	vect = cv.transform(data).toarray()
-    	my_prediction = classifier.predict(vect)
-    	return render_template('result.html', prediction=my_prediction)
+        message = request.form['message']
+        # retrieve additional context using RAG
+        context = retrieve_context(message)
+        enriched_input = f"{message}\n{context}" if context else message
+
+        label, score = sentiment_model.predict(enriched_input)
+        final_prediction = classify_label(label, score)
+
+        return render_template(
+            'result.html',
+            prediction=final_prediction,
+            score=round(score, 3),
+            raw_label=label
+        )
+
 
 if __name__ == '__main__':
-	app.run(debug=True)
+    app.run(debug=True)
+

--- a/rag_helper.py
+++ b/rag_helper.py
@@ -1,0 +1,37 @@
+from typing import List
+import pandas as pd
+
+try:
+    from haystack.document_stores import InMemoryDocumentStore
+    from haystack.nodes import BM25Retriever
+except ImportError:  # haystack may not be available in all environments
+    InMemoryDocumentStore = None
+    BM25Retriever = None
+
+document_store = None
+retriever = None
+
+
+def init_rag(doc_path: str = "Restaurant_Reviews.tsv") -> None:
+    """Initialise the Haystack DocumentStore and Retriever with reviews."""
+    global document_store, retriever
+    if InMemoryDocumentStore is None:
+        return
+    if document_store is not None:
+        return
+
+    reviews = pd.read_csv(doc_path, delimiter="\t", quoting=3)
+    docs = [{"content": row["Review"]} for _, row in reviews.iterrows()]
+    document_store = InMemoryDocumentStore()
+    document_store.write_documents(docs)
+    retriever = BM25Retriever(document_store=document_store)
+
+
+def retrieve_context(query: str, top_k: int = 3) -> str:
+    """Retrieve contextual documents for the given query."""
+    if retriever is None:
+        return ""
+    retrieved_docs = retriever.retrieve(query=query, top_k=top_k)
+    context_parts = [doc.content for doc in retrieved_docs]
+    return " \n".join(context_parts)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ scikit-learn>=0.18
 matplotlib>=1.4.3
 pandas>=0.19
 nltk>=3.4.5
+farm-haystack
+transformers
+torch

--- a/sentiment_model.py
+++ b/sentiment_model.py
@@ -1,0 +1,46 @@
+import re
+from typing import Tuple
+
+try:
+    from transformers import pipeline
+except ImportError:
+    pipeline = None
+
+# Pre-compiled regular expression for handling negation like "not good".
+NEGATION_PATTERN = re.compile(r"\b(?:not|no|n't)\s+(\w+)", re.IGNORECASE)
+
+
+class SentimentModel:
+    def __init__(self):
+        if pipeline is None:
+            self.model = None
+        else:
+            self.model = pipeline("sentiment-analysis")
+
+    @staticmethod
+    def _handle_negation(text: str) -> str:
+        def replacer(match: re.Match) -> str:
+            return match.group(0).replace(" ", "_")
+
+        return NEGATION_PATTERN.sub(replacer, text)
+
+    def predict(self, text: str) -> Tuple[str, float]:
+        """Return (label, score) for the provided text."""
+        if self.model is None:
+            return "neutral", 0.0
+        processed = self._handle_negation(text)
+        result = self.model(processed)[0]
+        label = result["label"].lower()
+        score = float(result["score"])
+        return label, score
+
+
+# Classification thresholds
+def classify_label(label: str, score: float) -> str:
+    """Map model output to positive/negative/neutral labels with thresholds."""
+    if label == "positive" and score >= 0.6:
+        return "positive"
+    if label == "negative" and score >= 0.6:
+        return "negative"
+    return "neutral"
+

--- a/static/styles.css
+++ b/static/styles.css
@@ -120,3 +120,16 @@ body{
 .safe{
     color: green;
 }
+
+/* Color coding for new sentiment labels */
+.positive{
+    color: green;
+}
+
+.negative{
+    color: red;
+}
+
+.neutral{
+    color: goldenrod;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
         <!-- Text Area -->
     	<div class="ml-container">
     		<form action="{{ url_for('predict') }}" method="POST">
-        		<textarea class='message-box' name="message" rows="15" cols="75" placeholder="Enter Your Review Here..."></textarea><br/>
+                    <textarea class='message-box' name="message" rows="15" cols="75" placeholder="Enter Your Review Here..." title="Enter a restaurant review for analysis."></textarea><br/>
         		<input type="submit" class="my-cta-button" value="Predict">
         	</form>
     	</div>

--- a/templates/result.html
+++ b/templates/result.html
@@ -21,15 +21,17 @@
     	</div>
 
 		<!-- Result -->
-		<div class="results">
-			{% if prediction==1 %}
-				<h1>Prediction: <span class='safe'>Great! This is a POSITIVE Review.</span></h1>
-				<img class="gif" src="{{ url_for('static', filename='positive-review.webp') }}" alt="Positive Review">
-			{% elif prediction==0 %}
-				<h1>Prediction: <span class='danger'>Oops! This is a NEGATIVE Review.</span></h1>
-				<img class="gif" src="{{ url_for('static', filename='negative-review.webp') }}" alt="Negative Review">
-			{% endif %}
-		</div>
+                <div class="results">
+                        {% if prediction == 'positive' %}
+                                <h1>Sentiment: <span class='positive' title="Model label: {{ raw_label }} | Score: {{ score }}">Positive</span></h1>
+                                <img class="gif" src="{{ url_for('static', filename='positive-review.webp') }}" alt="Positive Review">
+                        {% elif prediction == 'negative' %}
+                                <h1>Sentiment: <span class='negative' title="Model label: {{ raw_label }} | Score: {{ score }}">Negative</span></h1>
+                                <img class="gif" src="{{ url_for('static', filename='negative-review.webp') }}" alt="Negative Review">
+                        {% else %}
+                                <h1>Sentiment: <span class='neutral' title="Model label: {{ raw_label }} | Score: {{ score }}">Neutral</span></h1>
+                        {% endif %}
+                </div>
 
 		<!-- Footer -->
 		<div class='footer'>


### PR DESCRIPTION
## Summary
- switch Flask app to use new `SentimentModel`
- integrate a simple Retrieval Augmented Generation helper using Haystack
- show color‑coded results with tooltips in the templates
- add tooltip on textarea
- update CSS for the new result classes
- add required dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68583f6657d88333b8dad337b6773df7